### PR TITLE
fix: Resolve critical method name conflict preventing autocommands

### DIFF
--- a/lua/nvim-block-markers/init.lua
+++ b/lua/nvim-block-markers/init.lua
@@ -76,7 +76,7 @@ local function is_python_buffer(bufnr)
 end
 
 -- Setup autocommands (called once on plugin load)
-function M:setup()
+function M.init_autocommands()
     if autocommand_group then
         return -- Already set up
     end
@@ -233,6 +233,6 @@ function M:toggle_block_markers(bufnr)
 end
 
 -- Initialize the plugin
-M.setup()
+M.init_autocommands()
 
 return M


### PR DESCRIPTION
## Summary
- Fixes critical bug where markers never appeared due to autocommands not being set up
- Resolves method name conflict between `M:setup()` and `M.setup(opts)`

## Root Cause
The plugin had two functions with similar names:
1. `M.setup(opts)` - Configuration setup (uses dot notation)
2. `M:setup()` - Autocommand setup (uses colon notation)

The initialization code called `M.setup()` which invoked the configuration function instead of the autocommand setup, causing autocommands to never be created.

## Fix
- Renamed `M:setup()` to `M.init_autocommands()` for clarity
- Updated initialization call to use the correct function
- Autocommands are now properly created on plugin load

## Test plan
- [ ] Open a Python file - markers should appear automatically
- [ ] Edit code - markers should update in real-time
- [ ] Use `:BlockMarkerToggle` - should work as expected

This resolves the issue where the plugin loaded without errors but no markers appeared.

🤖 Generated with [Claude Code](https://claude.ai/code)