### PR TITLE
fix: Place markers on line above definitions, not on definition line

### DIFF
--- a/lua/nvim-block-markers/init.lua
+++ b/lua/nvim-block-markers/init.lua
@@ -172,20 +172,22 @@ function M:add_block_markers(bufnr)
 
         for _, node, metadata in query:iter_captures(root, bufnr, 0, -1) do
             local start_row, _, _, _ = node:range()
-            local line_num = start_row
+            local marker_line = start_row - 1  -- Place marker on line above definition
+            
+            -- Only place marker if line above exists and is empty
+            if marker_line >= 0 then
+                local line_content = api.nvim_buf_get_lines(bufnr, marker_line, marker_line + 1, false)[1] or ""
+                if line_content == "" then
+                    local opts = {
+                        end_line = marker_line,
+                        id = marker_line,
+                        virt_text = {{params.marker, "Comment"}},
+                        virt_text_pos = "overlay"
+                    }
 
-            -- make sure there is no text on that line already (truly empty lines only)
-            local line_content = api.nvim_buf_get_lines(bufnr, line_num, line_num + 1, false)[1] or ""
-            if line_content == "" then
-                local opts = {
-                    end_line = line_num,
-                    id = line_num,
-                    virt_text = {{params.marker, "Comment"}},
-                    virt_text_pos = "overlay"
-                }
-
-                -- Add virtual line: https://jdhao.github.io/2021/09/09/nvim_use_virtual_text/
-                local mark_id = api.nvim_buf_set_extmark(bufnr, ns_id, line_num, 0, opts)
+                    -- Add virtual line: https://jdhao.github.io/2021/09/09/nvim_use_virtual_text/
+                    local mark_id = api.nvim_buf_set_extmark(bufnr, ns_id, marker_line, 0, opts)
+                end
             end
         end
     end

--- a/lua/nvim-block-markers/init.lua
+++ b/lua/nvim-block-markers/init.lua
@@ -180,7 +180,7 @@ function M:add_block_markers(bufnr)
                 if line_content == "" then
                     local opts = {
                         end_line = marker_line,
-                        id = marker_line,
+                        -- Let Neovim auto-generate unique IDs instead of using line numbers
                         virt_text = {{params.marker, "Comment"}},
                         virt_text_pos = "overlay"
                     }


### PR DESCRIPTION
## Summary
- Fixes critical bug where no markers appeared despite correct plugin setup
- Treesitter queries return definition lines, but markers should be placed on empty lines above

## Root Cause
The plugin was trying to place markers on definition lines themselves (e.g., `def hello_world():`), which always have content and fail the empty line check. Markers should be placed on the empty line above the definition.

## Fix
- Changed `line_num = start_row` to `marker_line = start_row - 1`
- Added bounds check to ensure `marker_line >= 0`
- Updated extmark placement to use `marker_line` instead of `line_num`

## Debug Evidence
Testing shows this fix correctly identifies and places markers:
- Line 2 (empty) → marker above `def hello_world():` ✅
- Line 22 (empty) → marker above `def another_function():` ✅
- Lines with content (class methods, decorated functions) correctly skipped

## Test plan
- [x] Debug script confirms extmark creation works with fix
- [ ] Test automatic marker placement on Python file open
- [ ] Test real-time updates during editing
- [ ] Verify markers appear above functions and classes

Resolves the issue where plugin loaded correctly but no visual markers appeared.

🤖 Generated with [Claude Code](https://claude.ai/code)