### PR TITLE
fix: Allow markers on whitespace-only lines for better UX

### DIFF
--- a/lua/nvim-block-markers/init.lua
+++ b/lua/nvim-block-markers/init.lua
@@ -177,7 +177,7 @@ function M:add_block_markers(bufnr)
             -- Only place marker if line above exists and is empty
             if marker_line >= 0 then
                 local line_content = api.nvim_buf_get_lines(bufnr, marker_line, marker_line + 1, false)[1] or ""
-                if line_content == "" then
+                if line_content:match("^%s*$") then  -- Allow empty lines or whitespace-only lines
                     local opts = {
                         end_line = marker_line,
                         -- Let Neovim auto-generate unique IDs instead of using line numbers


### PR DESCRIPTION
## Summary
- Changes empty line detection from strict (`line == ""`) to whitespace-tolerant (`line:match("^%s*$")`)
- Fixes inconsistent marker behavior where visually empty lines sometimes didn't get markers
- Improves user experience by making marker placement more intuitive

## Problem
Users reported inconsistent marker behavior where some "empty" lines would get markers while others wouldn't. Debug analysis revealed that lines containing only whitespace (spaces, tabs) were being treated as non-empty and skipped.

**Example:**
```python
def hello_world():
    pass
 ←── This line contains a space, no marker appeared
class TestClass:
    pass

class AnotherClass:  ←── This line is truly empty, marker appeared correctly
    pass
```

## Solution
Changed the empty line check from:
```lua
if line_content == "" then  -- Only truly empty lines
```
to:
```lua
if line_content:match("^%s*$") then  -- Empty or whitespace-only lines
```

## Behavior Change
Now places markers on:
- ✅ Truly empty lines (`""`)
- ✅ Space-only lines (`" "`, `"  "`)  
- ✅ Tab-only lines (`"\t"`, `"\t\t"`)
- ✅ Mixed whitespace (`"  \t "`)

## Test plan
- [x] Debug script confirms both empty and whitespace-only lines are detected
- [ ] Test marker placement consistency across different whitespace scenarios
- [ ] Verify markers appear reliably for class definitions with whitespace-only lines above
- [ ] Ensure no regression in normal empty line behavior

This makes the plugin behavior more predictable and user-friendly.

🤖 Generated with [Claude Code](https://claude.ai/code)